### PR TITLE
fix wasm build being unable to load assets

### DIFF
--- a/nix/desktop/default.nix
+++ b/nix/desktop/default.nix
@@ -26,10 +26,9 @@ rustPlatform.buildRustPackage {
 
   postInstall = # bash
     ''
-      mkdir -p $out/share/fonts/
-      cp ${fira-sans}/share/fonts/opentype/FiraSans-Bold.otf $out/share/fonts/
+      mkdir -p $out/bin/assets/fonts/
+      cp ${fira-sans}/share/fonts/opentype/FiraSans-Bold.otf $out/bin/assets/fonts/
       wrapProgram $out/bin/${pname} \
         --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeDependencies} \
-        --chdir $out/share
     '';
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,29 +7,13 @@ use rand::prelude::*;
 fn main() {
     App::new()
         .insert_resource(ClearColor(Srgba::hex("#1f2638").unwrap().into()))
-        .add_plugins(
-            DefaultPlugins
-                .set(WindowPlugin {
-                    primary_window: Some(Window {
-                        title: "2048".to_string(),
-                        ..default()
-                    }),
-                    ..default()
-                })
-                .set(AssetPlugin {
-                    file_path: std::env::current_dir()
-                        .unwrap()
-                        .into_os_string()
-                        .into_string()
-                        .unwrap(),
-                    processed_file_path: std::env::current_dir()
-                        .unwrap()
-                        .into_os_string()
-                        .into_string()
-                        .unwrap(),
-                    ..default()
-                }),
-        )
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "2048".to_string(),
+                ..default()
+            }),
+            ..default()
+        }))
         .init_resource::<FontSpec>()
         .add_systems(
             Startup,


### PR DESCRIPTION
remove setting for asset server to load from the current working directory